### PR TITLE
Updated instant send to retrieve content through a HTTP/GET request

### DIFF
--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -72,27 +72,19 @@ function gmucf_content_type( $content_type ) {
 function generate_email_markup( $post_id ) {
 	if ( ! defined( 'UCF_EMAIL_EDITOR__PLUGIN_DIR' ) ) return '';
 
-	global $wp_query;
-
-	$wp_the_query = $wp_query;
+	$permalink = get_permalink( $post_id );
 
 	$args = array(
-		'p'         => $post_id,
-		'post_type' => 'ucf-email'
+		'timeout' => 15
 	);
 
-	$query = new \WP_Query( $args );
+	$response = wp_remote_get( $permalink, $args );
 
-	$wp_query = $query;
+	if ( wp_remote_retrieve_response_code( $response ) >= 400 ) return null;
 
-	ob_start();
+	$body = wp_remote_retrieve_body( $response );
 
-	include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'templates/blank/blank-template.php';
-
-	// Reset wp_query
-	$wp_query = $wp_the_query;
-
-	return ob_get_clean();
+	return $body;
 }
 
 


### PR DESCRIPTION
<!---
Thank you for contributing to GMUCF-Utilities.

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updates the instant send feature for GMUCF to externally fetch the email content instead of generating it internally using PHP. This makes the feature more flexible, since we don't have to worry about what template(s) are being used as far as this feature is concerned.

**Motivation and Context**
Flexibility!

**How Has This Been Tested?**
Feel free to send some test emails from DEV. Everything should work peachy.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
